### PR TITLE
Prevent UnhandledPromiseRejectionWarning in node 7

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -36,16 +36,7 @@ function patchJasmineFn (obj, slot, fnArgIndex) {
         } else {
           returnValue = testFn.call(this);
           if (returnValue && returnValue.then) {
-            returnValue.then(() => {
-              done();
-            });
-
-            if (returnValue.catch && done.fail) {
-              returnValue.catch(error => {
-                done.fail(error);
-              });
-            }
-
+            returnValue.then(done, done.fail);
           } else {
             done();
           }


### PR DESCRIPTION
Starting from node 7, unhandled rejected promises are displaying a warning to the stdout: `UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): ...`

On top of that, a message telling that unhandled promise rejections will terminate the node process in the future.

The unhandled rejection occurs because the `returnValue.then(...)` statement returns a new rejected promise if the test is failing, but this returned promise isn't used.

This change makes promise resolution and rejection handling both at the same place, so no promise should be left unhandled.

Please note that although I didn't try, Chrome should behave in a similar way and print error messages in the console when a promise rejection is left unhandled. This patch fixes the problem there too.